### PR TITLE
File size reduction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.8]
+        python-version: [3.8]
         tensorflow-package: ['tensorflow', 'tensorflow==2.3.1']
     steps:
     - uses: actions/checkout@v2

--- a/onnx2keras.py
+++ b/onnx2keras.py
@@ -288,16 +288,10 @@ class TfKerasOperations(Operations):
     def op_batchnormalization(self, x, weight, bias, running_mean, running_var, momentum, epsilon):
         if  len(x.shape) != 4:
             raise NotImplementedError
-        moving_mean_initializer = self.keras.initializers.Constant(running_mean.view(np.ndarray))
-        moving_variance_initializer = self.keras.initializers.Constant(running_var.view(np.ndarray))
-        beta_initializer = self.keras.initializers.Constant(bias.view(np.ndarray))
-        gamma_initializer = self.keras.initializers.Constant(weight.view(np.ndarray))
-        norm = self.keras.layers.BatchNormalization(momentum=momentum, epsilon=epsilon,
-                                                    moving_mean_initializer=moving_mean_initializer,
-                                                    moving_variance_initializer=moving_variance_initializer,
-                                                    beta_initializer=beta_initializer,
-                                                    gamma_initializer=gamma_initializer)
+        norm = self.keras.layers.BatchNormalization(momentum=momentum, epsilon=epsilon)
         out = norm(x)
+        norm.set_weights([weight.view(np.ndarray), bias.view(np.ndarray),
+                          running_mean.view(np.ndarray), running_var.view(np.ndarray)])
         out.data_format = x.data_format
         return [out]
 


### PR DESCRIPTION
Batchnorm layers now use set_weights() instead of keras.initializers.Constant(). My testing shows that this decreases the file size of the keras *.h5 model of a few MB with a mobilenetV2 based model.

Had to remove python 3.5 (which is deprecated as of Sept 2020) from the tests as there where som problem installing the dependencies.