### PR TITLE
Broadcast input2 to input1 shape if constant and empty

### DIFF
--- a/onnx2keras.py
+++ b/onnx2keras.py
@@ -62,7 +62,10 @@ def ensure_compatible_data_format(a, b):
     if compatible_data_format(a.data_format, b.data_format):
         return a, b
     if b.data_format is OnnxConstant:
-        return a, ensure_data_format(b, a.data_format)
+        if len(b.shape) == 0:
+            return a, tf.broadcast_to(b, a.shape)
+        else:
+            return a, ensure_data_format(b, a.data_format)
     return ensure_data_format(a, b.data_format), b
 
 class Constant(np.ndarray):


### PR DESCRIPTION
I hit an add_op that was adding an ImageInterleavedBatch to a constant float (1.0f).
The constant had no shape and the current code does not handle this.