### PR TITLE
Batch Norm: Allow 2-dim and 3-dim BN

### DIFF
--- a/onnx2keras.py
+++ b/onnx2keras.py
@@ -286,8 +286,6 @@ class TfKerasOperations(Operations):
             raise NotImplementedError
 
     def op_batchnormalization(self, x, weight, bias, running_mean, running_var, momentum, epsilon):
-        if  len(x.shape) != 4:
-            raise NotImplementedError
         norm = self.keras.layers.BatchNormalization(momentum=momentum, epsilon=epsilon)
         out = norm(x)
         norm.set_weights([weight.view(np.ndarray), bias.view(np.ndarray),

--- a/test_onnx2keras.py
+++ b/test_onnx2keras.py
@@ -179,6 +179,15 @@ class TestOnnx:
         x = np.random.rand(1, 3, 224, 224).astype(np.float32)
         convert_and_compare_output(net, x)
 
+    def test_batchnorm1d(self):
+        bn = torch.nn.BatchNorm1d(3)
+        bn.running_mean.uniform_()
+        bn.running_var.uniform_()
+        net = torch.nn.Sequential(GlobalAvgPool(), bn, torch.nn.ReLU())
+        net.eval()
+        x = np.random.rand(1, 3, 224, 224).astype(np.float32)
+        convert_and_compare_output(net, x, image_out=False)
+
     def test_clamp(self):
         class Clamp(Module):
             def forward(self, x):


### PR DESCRIPTION
I hit a batch norm with shape: (1, 512) that was hitting this. After removing the NotImplemented exception, it converted fine.
Is there a reason it would not support 2 and 3 dimension batch normalisation?

![image](https://user-images.githubusercontent.com/61218/131785062-058cb9a9-c0cb-449c-8e87-d2a49915204f.png)
