### PR TITLE
Split grouped convs for tflite compatibility

### DIFF
--- a/test_onnx2keras.py
+++ b/test_onnx2keras.py
@@ -220,6 +220,11 @@ class TestOnnx:
         x = np.random.rand(1, 8, 224, 224).astype(np.float32)
         convert_and_compare_output(net, x)
 
+    def test_groupwise_no_bias(self):
+        net = torch.nn.Conv2d(6, 12, 4, groups=3, bias=False)
+        x = np.random.rand(1, 6, 224, 224).astype(np.float32)
+        convert_and_compare_output(net, x)
+
     def test_depthwise_no_bias(self):
         net = torch.nn.Sequential(torch.nn.Conv2d(3, 3, 7, groups=3, bias=False), torch.nn.ReLU())
         x = np.random.rand(1, 3, 224, 224).astype(np.float32)


### PR DESCRIPTION
See: https://github.com/tensorflow/tensorflow/issues/4004

This PR changes the Conv2D layer creation:
group = n_channels -> Depthwise Conv2D
group = 1 -> Regular Conv2D
else -> Split into group number of Conv2D layers

Is it fine if this is the default behavior or maybe a command line arg (for example "make_tflite_compatible_model") for changing the behavior is prefererad?