### PR TITLE
Fix op_pad signature

### DIFF
--- a/onnx2keras.py
+++ b/onnx2keras.py
@@ -351,7 +351,7 @@ class TfKerasOperations(Operations):
             raise NotImplementedError
         return [out]
 
-    def op_pad(self, x, pads, mode, value=0.0):
+    def op_pad(self, x, pads, value=0.0, mode = b'constant'):
         x = ensure_data_format(x, InterleavedImageBatch)
         if mode == b'constant' and len(pads) == 8:
             assert len(x.shape) * 2 == len(pads)


### PR DESCRIPTION
When using torch.constant_pad_nd, the conversion gives:

> x = getattr(self, 'op_' + op_type.lower())(*inputs, **attrs)
> TypeError: op_pad() got multiple values for argument 'mode'

I found the order appears to be incorrect in the signature