### PR TITLE
Fix slice for TFLite quantization

### DIFF
--- a/onnx2keras.py
+++ b/onnx2keras.py
@@ -451,16 +451,28 @@ class TfKerasOperations(Operations):
             if len(x.shape) != 4:
                 raise NotImplementedError
             if len(axes) == 1 and starts[0] != ends[0]:
-                if axes[0] == 0:
-                    out = x[starts[0]:ends[0]:steps[0],:,:,:]
-                elif axes[0] == 1:
-                    out = x[:,:,:,starts[0]:ends[0]:steps[0]]
-                elif axes[0] == 2:
-                    out = x[:,starts[0]:ends[0]:steps[0],:,:]
-                elif axes[0] == 3:
-                    out = x[:,:,starts[0]:ends[0]:steps[0],:]
+                if ends[0] == 2**63-1: # INT_MAX
+                    if axes[0] == 0:
+                        out = x[starts[0]::steps[0],:,:,:]
+                    elif axes[0] == 1:
+                        out = x[:,:,:,starts[0]::steps[0]]
+                    elif axes[0] == 2:
+                        out = x[:,starts[0]::steps[0],:,:]
+                    elif axes[0] == 3:
+                        out = x[:,:,starts[0]::steps[0],:]
+                    else:
+                        raise NotImplementedError
                 else:
-                    raise NotImplementedError
+                    if axes[0] == 0:
+                        out = x[starts[0]:ends[0]:steps[0],:,:,:]
+                    elif axes[0] == 1:
+                        out = x[:,:,:,starts[0]:ends[0]:steps[0]]
+                    elif axes[0] == 2:
+                        out = x[:,starts[0]:ends[0]:steps[0],:,:]
+                    elif axes[0] == 3:
+                        out = x[:,:,starts[0]:ends[0]:steps[0],:]
+                    else:
+                        raise NotImplementedError
             elif tuple(axes) == (2,3) and starts[0] != ends[0] and starts[1] != ends[1]:
                 out = x[:,starts[0]:ends[0]:steps[0],starts[1]:ends[1]:steps[1],:]
             else:

--- a/test_onnx2keras.py
+++ b/test_onnx2keras.py
@@ -517,6 +517,26 @@ class TestOnnx:
         x = np.random.rand(2, 3, 16, 32).astype(np.float32)
         convert_and_compare_output(net, x, image_out=False)
 
+    def test_focus(self):
+        class Focus(Module):
+            def forward(self, x):
+                patch_top_left = x[..., ::2, ::2]
+                patch_top_right = x[..., ::2, 1::2]
+                patch_bot_left = x[..., 1::2, ::2]
+                patch_bot_right = x[..., 1::2, 1::2]
+                x = torch.cat(
+                    (
+                        patch_top_left,
+                        patch_bot_left,
+                        patch_top_right,
+                        patch_bot_right,
+                    ),
+                    dim=1,
+                )
+                return x
+        net = torch.nn.Sequential(Focus(), torch.nn.ReLU())
+        x = np.random.rand(4, 3, 16, 16).astype(np.float32)
+        convert_and_compare_output(net, x, opset_version=11)
 
     # def test_inception_v3(self):
     #     net = models.Inception3(aux_logits=False)

--- a/test_onnx2keras.py
+++ b/test_onnx2keras.py
@@ -517,7 +517,7 @@ class TestOnnx:
         x = np.random.rand(2, 3, 16, 32).astype(np.float32)
         convert_and_compare_output(net, x, image_out=False)
 
-    def test_focus(self):
+    def test_yolox_focus_module(self):
         class Focus(Module):
             def forward(self, x):
                 patch_top_left = x[..., ::2, ::2]


### PR DESCRIPTION
I have used this project to convert [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX/) to Keras and then to TFLite, but TFLite post training quantization fails due to an error related to the slice operation. When exporting a slice with no end, PyTorch sets end to `INT_MAX` as [recommended](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Slice). This small change omits the end position when end is equal to `INT_MAX`, which fixes the error.

I also added a test with the [Focus module](https://github.com/Megvii-BaseDetection/YOLOX/blob/6c682609f989497a5962504daaddcbc2994a7e0f/yolox/models/network_blocks.py#L188) used in YOLOX that contains the slice operations of interest.