### PR TITLE
fix reshape assertion

### DIFF
--- a/onnx2keras.py
+++ b/onnx2keras.py
@@ -597,7 +597,7 @@ class TfKerasOperations(Operations):
 
     def op_reshape(self, x, shape):
         x = ensure_data_format(x, OnnxTensor)
-        assert x.shape[0] == shape[0]
+        assert x.shape[0] == shape[0] or shape[0] == -1
         out = self.keras.layers.Reshape(shape[1:])(x)
         out.data_format = OnnxTensor
         return [out]


### PR DESCRIPTION
### Describe your changes

I came across a problem where the assertion for op_reshape failed because x.shape[0] was 64 (my batch size) but shape[0] was -1. Since this is not a mismatch, it should pass the assertion.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
